### PR TITLE
Install libatlas-base-dev for Blas package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
  - 1.2
  - release
  - tip
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq libatlas-base-dev
 install:
  - go get github.com/smartystreets/goconvey/convey
  - go get -v ./...


### PR DESCRIPTION
The Go blas package requires libcblas to be present on the system.
Travis environments run Ubuntu Linux so we need to install
libatlas-base-dev.

Signed-off-by: Pekka Enberg penberg@iki.fi
