### PR TITLE
Fixed incorrect instance shuffling algorithm.

### DIFF
--- a/base/instances.go
+++ b/base/instances.go
@@ -5,8 +5,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/gonum/matrix/mat64"
 	"math/rand"
+
+	"github.com/gonum/matrix/mat64"
 )
 
 // SortDirection specifies sorting direction...
@@ -507,7 +508,7 @@ func (inst *Instances) GeneratePredictionVector() *Instances {
 // Shuffle randomizes the row order in place
 func (inst *Instances) Shuffle() {
 	for i := 0; i < inst.Rows; i++ {
-		j := rand.Intn(inst.Rows)
+		j := rand.Intn(i + 1)
 		inst.swapRows(i, j)
 	}
 }


### PR DESCRIPTION
There was a minor implementation bug in `base/instances.go` in regards to the `Shuffle()` method on `Instances` that causes it to create a non-uniform distribution of shuffle permutations. I've changed it to implement the correct Fisher-Yates algorithm.
