### PR TITLE
trees: Handling FloatAttributes.

### DIFF
--- a/examples/datasets/c45-numeric.csv
+++ b/examples/datasets/c45-numeric.csv
@@ -1,0 +1,15 @@
+Attribute1,Attribute2,Attribute3,Class
+A,70,T,A
+A,90,T,B
+A,85,F,B
+A,95,F,B
+A,70,F,A
+B,90,T,A
+B,78,F,A
+B,65,T,A
+B,75,F,A
+C,80,T,B
+C,70,T,B
+C,80,F,A
+C,80,F,A
+C,96,F,A

--- a/examples/datasets/sources.txt
+++ b/examples/datasets/sources.txt
@@ -1,0 +1,4 @@
+c45-numeric.csv: www.mgt.ncu.edu.tw/~wabble/School/C45.ppt
+tennis.csv: "Machine Learning", Tom Mitchell, McGraw-Hill, 1997 (http://books.google.co.uk/books?id=xOGAngEACAAJ&dq=machine+learning,+mitchell&hl=en&sa=X&ei=zvpMVPz8IseN7Aa454DYBg&ved=0CFYQ6AEwBw)
+
+ 

--- a/trees/entropy.go
+++ b/trees/entropy.go
@@ -3,34 +3,37 @@ package trees
 import (
 	"github.com/sjwhitworth/golearn/base"
 	"math"
+	"sort"
 )
 
 //
 // Information gain rule generator
 //
 
+// InformationGainRuleGenerator generates DecisionTreeRules which
+// maximize information gain at each node.
 type InformationGainRuleGenerator struct {
 }
 
-// GenerateSplitAttribute returns the non-class Attribute which maximises the
-// information gain.
+// GenerateSplitRule returns a DecisionTreeNode based on a non-class Attribute
+// which maximises the information gain.
 //
 // IMPORTANT: passing a base.Instances with no Attributes other than the class
 // variable will panic()
-func (r *InformationGainRuleGenerator) GenerateSplitAttribute(f base.FixedDataGrid) base.Attribute {
+func (r *InformationGainRuleGenerator) GenerateSplitRule(f base.FixedDataGrid) *DecisionTreeRule {
 
 	attrs := f.AllAttributes()
 	classAttrs := f.AllClassAttributes()
 	candidates := base.AttributeDifferenceReferences(attrs, classAttrs)
 
-	return r.GetSplitAttributeFromSelection(candidates, f)
+	return r.GetSplitRuleFromSelection(candidates, f)
 }
 
-// GetSplitAttributeFromSelection returns the class Attribute which maximises
-// the information gain amongst consideredAttributes
+// GetSplitRuleFromSelection returns a DecisionTreeRule which maximises
+// the information gain amongst the considered Attributes.
 //
 // IMPORTANT: passing a zero-length consideredAttributes parameter will panic()
-func (r *InformationGainRuleGenerator) GetSplitAttributeFromSelection(consideredAttributes []base.Attribute, f base.FixedDataGrid) base.Attribute {
+func (r *InformationGainRuleGenerator) GetSplitRuleFromSelection(consideredAttributes []base.Attribute, f base.FixedDataGrid) *DecisionTreeRule {
 
 	var selectedAttribute base.Attribute
 
@@ -43,6 +46,7 @@ func (r *InformationGainRuleGenerator) GetSplitAttributeFromSelection(considered
 	// for each randomly chosen attribute, and pick the one
 	// which maximises it
 	maxGain := math.Inf(-1)
+	selectedVal := math.Inf(1)
 
 	// Compute the base entropy
 	classDist := base.GetClassDistribution(f)
@@ -50,22 +54,97 @@ func (r *InformationGainRuleGenerator) GetSplitAttributeFromSelection(considered
 
 	// Compute the information gain for each attribute
 	for _, s := range consideredAttributes {
-		proposedClassDist := base.GetClassDistributionAfterSplit(f, s)
-		localEntropy := getSplitEntropy(proposedClassDist)
-		informationGain := baseEntropy - localEntropy
+		var informationGain float64
+		var splitVal float64
+		if fAttr, ok := s.(*base.FloatAttribute); ok {
+			var attributeEntropy float64
+			attributeEntropy, splitVal = getNumericAttributeEntropy(f, fAttr)
+			informationGain = baseEntropy - attributeEntropy
+		} else {
+			proposedClassDist := base.GetClassDistributionAfterSplit(f, s)
+			localEntropy := getSplitEntropy(proposedClassDist)
+			informationGain = baseEntropy - localEntropy
+		}
+
 		if informationGain > maxGain {
 			maxGain = informationGain
 			selectedAttribute = s
+			selectedVal = splitVal
 		}
 	}
 
 	// Pick the one which maximises IG
-	return selectedAttribute
+	return &DecisionTreeRule{selectedAttribute, selectedVal}
 }
 
 //
 // Entropy functions
 //
+
+type numericSplitRef struct {
+	val   float64
+	class string
+}
+
+type splitVec []numericSplitRef
+
+func (a splitVec) Len() int           { return len(a) }
+func (a splitVec) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a splitVec) Less(i, j int) bool { return a[i].val < a[j].val }
+
+func getNumericAttributeEntropy(f base.FixedDataGrid, attr *base.FloatAttribute) (float64, float64) {
+
+	// Resolve Attribute
+	attrSpec, err := f.GetAttribute(attr)
+	if err != nil {
+		panic(err)
+	}
+
+	// Build sortable vector
+	_, rows := f.Size()
+	refs := make([]numericSplitRef, rows)
+	f.MapOverRows([]base.AttributeSpec{attrSpec}, func(val [][]byte, row int) (bool, error) {
+		cls := base.GetClass(f, row)
+		v := base.UnpackBytesToFloat(val[0])
+		refs[row] = numericSplitRef{v, cls}
+		return true, nil
+	})
+
+	// Sort
+	sort.Sort(splitVec(refs))
+
+	generateCandidateSplitDistribution := func(val float64) map[string]map[string]int {
+		presplit := make(map[string]int)
+		postplit := make(map[string]int)
+		for _, i := range refs {
+			if i.val < val {
+				presplit[i.class]++
+			} else {
+				postplit[i.class]++
+			}
+		}
+		ret := make(map[string]map[string]int)
+		ret["0"] = presplit
+		ret["1"] = postplit
+		return ret
+	}
+
+	minSplitEntropy := math.Inf(1)
+	minSplitVal := math.Inf(1)
+	// Consider each possible function
+	for i := 0; i < len(refs)-1; i++ {
+		val := refs[i].val + refs[i+1].val
+		val /= 2
+		splitDist := generateCandidateSplitDistribution(val)
+		splitEntropy := getSplitEntropy(splitDist)
+		if splitEntropy < minSplitEntropy {
+			minSplitEntropy = splitEntropy
+			minSplitVal = val
+		}
+	}
+
+	return minSplitEntropy, minSplitVal
+}
 
 // getSplitEntropy determines the entropy of the target
 // class distribution after splitting on an base.Attribute

--- a/trees/gini.go
+++ b/trees/gini.go
@@ -1,0 +1,113 @@
+package trees
+
+import (
+	"github.com/sjwhitworth/golearn/base"
+	"math"
+)
+
+//
+// Gini-coefficient rule generator
+//
+
+// GiniCoefficientRuleGenerator generates DecisionTreeRules which minimize
+// the Geni impurity coefficient at each node.
+type GiniCoefficientRuleGenerator struct {
+}
+
+// GenerateSplitRule returns the non-class Attribute-based DecisionTreeRule
+// which maximises the information gain.
+//
+// IMPORTANT: passing a base.Instances with no Attributes other than the class
+// variable will panic()
+func (g *GiniCoefficientRuleGenerator) GenerateSplitRule(f base.FixedDataGrid) *DecisionTreeRule {
+
+	attrs := f.AllAttributes()
+	classAttrs := f.AllClassAttributes()
+	candidates := base.AttributeDifferenceReferences(attrs, classAttrs)
+
+	return g.GetSplitRuleFromSelection(candidates, f)
+}
+
+// GetSplitRuleFromSelection returns the DecisionTreeRule which maximises
+// the information gain amongst consideredAttributes
+//
+// IMPORTANT: passing a zero-length consideredAttributes parameter will panic()
+func (g *GiniCoefficientRuleGenerator) GetSplitRuleFromSelection(consideredAttributes []base.Attribute, f base.FixedDataGrid) *DecisionTreeRule {
+
+	var selectedAttribute base.Attribute
+	var selectedVal float64
+
+	// Parameter check
+	if len(consideredAttributes) == 0 {
+		panic("More Attributes should be considered")
+	}
+
+	// Minimize the averagge Gini index
+	minGini := math.Inf(1)
+	for _, s := range consideredAttributes {
+		var proposedDist map[string]map[string]int
+		var splitVal float64
+		if fAttr, ok := s.(*base.FloatAttribute); ok {
+			_, splitVal = getNumericAttributeEntropy(f, fAttr)
+			proposedDist = base.GetClassDistributionAfterThreshold(f, fAttr, splitVal)
+		} else {
+			proposedDist = base.GetClassDistributionAfterSplit(f, s)
+		}
+		avgGini := computeAverageGiniIndex(proposedDist)
+		if avgGini < minGini {
+			minGini = avgGini
+			selectedAttribute = s
+			selectedVal = splitVal
+		}
+	}
+
+	return &DecisionTreeRule{selectedAttribute, selectedVal}
+}
+
+//
+// Utility functions
+//
+
+// computeGini computes the Gini impurity measure
+func computeGini(s map[string]int) float64 {
+	// Compute probability map
+	p := make(map[string]float64)
+	for i := range s {
+		if p[i] == 0 {
+			continue
+		}
+		p[i] = 1.0 / float64(p[i])
+	}
+	// Compute overall sum
+	sum := 0.0
+	for i := range p {
+		sum += p[i] * p[i]
+	}
+
+	return 1.0 - sum
+}
+
+// computeGiniImpurity computes the average Gini index of a
+// proposed split
+func computeAverageGiniIndex(s map[string]map[string]int) float64 {
+
+	// Figure out the total number of things in this map
+	total := 0
+	for i := range s {
+		for j := range s[i] {
+			total += s[i][j]
+		}
+	}
+
+	sum := 0.0
+	for i := range s {
+		subtotal := 0.0
+		for j := range s[i] {
+			subtotal += float64(s[i][j])
+		}
+		cf := subtotal / float64(total)
+		cf *= computeGini(s[i])
+		sum += cf
+	}
+	return sum
+}

--- a/trees/gr.go
+++ b/trees/gr.go
@@ -1,0 +1,76 @@
+package trees
+
+import (
+	"github.com/sjwhitworth/golearn/base"
+	"math"
+)
+
+//
+// Information Gatio Ratio generator
+//
+
+// InformationGainRatioRuleGenerator generates DecisionTreeRules which
+// maximise the InformationGain at each node.
+type InformationGainRatioRuleGenerator struct {
+}
+
+// GenerateSplitRule returns a DecisionTreeRule which maximises information
+// gain ratio considering every available Attribute.
+//
+// IMPORTANT: passing a base.Instances with no Attributes other than the class
+// variable will panic()
+func (r *InformationGainRatioRuleGenerator) GenerateSplitRule(f base.FixedDataGrid) *DecisionTreeRule {
+
+	attrs := f.AllAttributes()
+	classAttrs := f.AllClassAttributes()
+	candidates := base.AttributeDifferenceReferences(attrs, classAttrs)
+
+	return r.GetSplitRuleFromSelection(candidates, f)
+}
+
+// GetSplitRuleFromSelection returns the DecisionRule which maximizes information gain,
+// considering only a subset of Attributes.
+//
+// IMPORTANT: passing a zero-length consideredAttributes parameter will panic()
+func (r *InformationGainRatioRuleGenerator) GetSplitRuleFromSelection(consideredAttributes []base.Attribute, f base.FixedDataGrid) *DecisionTreeRule {
+
+	var selectedAttribute base.Attribute
+	var selectedVal float64
+
+	// Parameter check
+	if len(consideredAttributes) == 0 {
+		panic("More Attributes should be considered")
+	}
+
+	// Next step is to compute the information gain at this node
+	// for each randomly chosen attribute, and pick the one
+	// which maximises it
+	maxRatio := math.Inf(-1)
+
+	// Compute the base entropy
+	classDist := base.GetClassDistribution(f)
+	baseEntropy := getBaseEntropy(classDist)
+
+	// Compute the information gain for each attribute
+	for _, s := range consideredAttributes {
+		var informationGain float64
+		var localEntropy float64
+		var splitVal float64
+		if fAttr, ok := s.(*base.FloatAttribute); ok {
+			localEntropy, splitVal = getNumericAttributeEntropy(f, fAttr)
+		} else {
+			proposedClassDist := base.GetClassDistributionAfterSplit(f, s)
+			localEntropy = getSplitEntropy(proposedClassDist)
+		}
+		informationGain = baseEntropy - localEntropy
+		informationGainRatio := informationGain / localEntropy
+		if informationGainRatio > maxRatio {
+			maxRatio = informationGainRatio
+			selectedAttribute = s
+			selectedVal = splitVal
+		}
+	}
+
+	// Pick the one which maximises IG
+	return &DecisionTreeRule{selectedAttribute, selectedVal}
+}

--- a/trees/random.go
+++ b/trees/random.go
@@ -12,14 +12,15 @@ type RandomTreeRuleGenerator struct {
 	internalRule InformationGainRuleGenerator
 }
 
-// GenerateSplitAttribute returns the best attribute out of those randomly chosen
+// GenerateSplitRule returns the best attribute out of those randomly chosen
 // which maximises Information Gain
-func (r *RandomTreeRuleGenerator) GenerateSplitAttribute(f base.FixedDataGrid) base.Attribute {
+func (r *RandomTreeRuleGenerator) GenerateSplitRule(f base.FixedDataGrid) *DecisionTreeRule {
+
+	var consideredAttributes []base.Attribute
 
 	// First step is to generate the random attributes that we'll consider
 	allAttributes := base.AttributeDifferenceReferences(f.AllAttributes(), f.AllClassAttributes())
 	maximumAttribute := len(allAttributes)
-	consideredAttributes := make([]base.Attribute, 0)
 
 	attrCounter := 0
 	for {
@@ -42,7 +43,7 @@ func (r *RandomTreeRuleGenerator) GenerateSplitAttribute(f base.FixedDataGrid) b
 		attrCounter++
 	}
 
-	return r.internalRule.GetSplitAttributeFromSelection(consideredAttributes, f)
+	return r.internalRule.GetSplitRuleFromSelection(consideredAttributes, f)
 }
 
 // RandomTree builds a decision tree by considering a fixed number


### PR DESCRIPTION
This patch adds:
- Gini index and information gain ratio as `DecisionTree` split options;
- handling for numeric Attributes (split point chosen naïvely on the basis of maximum entropy);
- A couple of additional utility functions in `base/`
- A new dataset (see `sources.txt`) for testing.

Performance on Iris performs markedly without discretisation.
