### PR TITLE
Removed decimal precision formatting from String() string for MultiLayerNet.

### DIFF
--- a/neural/layered.go
+++ b/neural/layered.go
@@ -49,7 +49,7 @@ func NewMultiLayerNet(layers []int) *MultiLayerNet {
 
 // String returns a human-readable summary of this network.
 func (m *MultiLayerNet) String() string {
-	return fmt.Sprintf("MultiLayerNet(%v, %v, %.2f, %.2f, %d", m.layers, m.network, m.Convergence, m.LearningRate, m.MaxIterations)
+	return fmt.Sprintf("MultiLayerNet(%v, %v, %f, %f, %d", m.layers, m.network, m.Convergence, m.LearningRate, m.MaxIterations)
 }
 
 func (m *MultiLayerNet) convertToFloatInsts(X base.FixedDataGrid) base.FixedDataGrid {


### PR DESCRIPTION
Convergence and LearningRate values less than 0.00, ie. 0.003, were being printed as 0.00 which was incredibly misleading when debugging.