### PR TITLE
Travis: drop support for go 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: go
-go: 
- - 1.3
+go:
  - 1.4
+ - 1.5
+ - 1.6
  - release
  - tip
+env:
+ # Temporary workaround for go 1.6
+ - GODEBUG=cgocheck=0
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq libatlas-base-dev


### PR DESCRIPTION
Fixes #133 and #134, temporary workaround for #129 so we can continue testing.