### PR TITLE
Fix go vet complaints

### DIFF
--- a/base/categorical.go
+++ b/base/categorical.go
@@ -10,7 +10,7 @@ import (
 // - useful for representing classes.
 type CategoricalAttribute struct {
 	Name   string
-	values []string `json:"values"`
+	values []string
 }
 
 // MarshalJSON returns a JSON version of this Attribute.

--- a/base/conversion.go
+++ b/base/conversion.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"fmt"
+
 	"github.com/gonum/matrix/mat64"
 )
 
@@ -9,7 +10,7 @@ func checkAllAttributesAreFloat(attrs []Attribute) error {
 	// Check that all the attributes are float
 	for _, a := range attrs {
 		if _, ok := a.(*FloatAttribute); !ok {
-			fmt.Errorf("All []Attributes to this method must be FloatAttributes")
+			return fmt.Errorf("All []Attributes to this method must be FloatAttributes")
 		}
 	}
 	return nil

--- a/base/filtered.go
+++ b/base/filtered.go
@@ -157,7 +157,7 @@ func (l *LazilyFilteredInstances) transformNewToOldAttribute(as AttributeSpec) (
 func (l *LazilyFilteredInstances) Get(as AttributeSpec, row int) []byte {
 	asOld, err := l.transformNewToOldAttribute(as)
 	if err != nil {
-		panic(fmt.Sprintf("Attribute %s could not be resolved. (Error: %s)", as, err))
+		panic(fmt.Sprintf("Attribute %s could not be resolved. (Error: %s)", as.String(), err.Error()))
 	}
 	byteSeq := l.src.Get(asOld, row)
 	if l.unfilteredMap[as.attr] {
@@ -177,7 +177,7 @@ func (l *LazilyFilteredInstances) MapOverRows(asv []AttributeSpec, mapFunc func(
 	for i, a := range asv {
 		old, err := l.transformNewToOldAttribute(a)
 		if err != nil {
-			return fmt.Errorf("Couldn't fetch old Attribute: '%s'", a)
+			return fmt.Errorf("Couldn't fetch old Attribute: '%s'", a.String())
 		}
 		oldAsv[i] = old
 	}

--- a/base/fixed.go
+++ b/base/fixed.go
@@ -69,7 +69,7 @@ func (f *FixedAttributeGroup) set(col int, row int, val []byte) {
 	// Copy the value in
 	copied := copy(f.alloc[offset:], val)
 	if copied != f.size {
-		panic(fmt.Sprintf("set() terminated by only copying %d bytes", copied, f.size))
+		panic(fmt.Sprintf("set() terminated by only copying %d bytes, should be %d", copied, f.size))
 	}
 
 	row++

--- a/base/serialize.go
+++ b/base/serialize.go
@@ -132,9 +132,9 @@ func deserializeAttributes(data []byte) []Attribute {
 
 	// Define a JSON shim Attribute
 	type JSONAttribute struct {
-		Type string          `json:type`
-		Name string          `json:name`
-		Attr json.RawMessage `json:attr`
+		Type string          `json:"type"`
+		Name string          `json:"name"`
+		Attr json.RawMessage `json:"attr"`
 	}
 
 	var ret []Attribute

--- a/clustering/clustering.go
+++ b/clustering/clustering.go
@@ -3,6 +3,7 @@ package clustering
 
 import (
 	"fmt"
+
 	"github.com/sjwhitworth/golearn/base"
 	"github.com/sjwhitworth/golearn/metrics/pairwise"
 )
@@ -66,7 +67,7 @@ func (ref ClusterMap) Equals(other ClusterMap) (bool, error) {
 			if c3, ok := clusterIdMap[c2]; ok { // what's our correspondance with c2?
 				if c1 != c3 {
 					// if c1 is not what we've currently got, error out
-					return false, fmt.Errorf("ref point %d (cluster %d) is assigned to a different cluster (%d) in ref %s", p, c2, c1, clusterIdMap)
+					return false, fmt.Errorf("ref point %d (cluster %d) is assigned to a different cluster (%d) in ref %+v", p, c2, c1, clusterIdMap)
 				}
 			} else {
 				clusterIdMap[c2] = c1
@@ -97,7 +98,7 @@ func (ref ClusterMap) Equals(other ClusterMap) (bool, error) {
 	for cOld := range other {
 		cNew := clusterIdMap[cOld]
 		if !arraysEqual(ref[cNew], other[cOld]) {
-			return false, fmt.Errorf("Re-labelled cluster %d => %d doesn't contain the same points (%s, %s)", cOld, cNew, ref[cNew], other[cOld])
+			return false, fmt.Errorf("Re-labelled cluster %d => %d doesn't contain the same points (%d, %d)", cOld, cNew, ref[cNew], other[cOld])
 		}
 		newMap[cNew] = other[cOld]
 	}

--- a/filters/binning.go
+++ b/filters/binning.go
@@ -2,8 +2,9 @@ package filters
 
 import (
 	"fmt"
-	"github.com/sjwhitworth/golearn/base"
 	"math"
+
+	"github.com/sjwhitworth/golearn/base"
 )
 
 // BinningFilter does equal-width binning for numeric
@@ -31,7 +32,7 @@ func NewBinningFilter(d base.FixedDataGrid, bins int) *BinningFilter {
 }
 
 func (b *BinningFilter) String() string {
-	return fmt.Sprintf("BinningFilter(%d Attribute(s), %d bin(s)", b.attrs, b.bins)
+	return fmt.Sprintf("BinningFilter(%d Attribute(s), %d bin(s)", len(b.attrs), b.bins)
 }
 
 // Train computes and stores the bin values

--- a/filters/chimerge_freq.go
+++ b/filters/chimerge_freq.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 )
 
+// FrequencyTableEntry is a struct holding a value and a map of frequency
 type FrequencyTableEntry struct {
 	Value     float64
 	Frequency map[string]int
 }
 
 func (t *FrequencyTableEntry) String() string {
-	return fmt.Sprintf("%.2f %s", t.Value, t.Frequency)
+	return fmt.Sprintf("%.2f %+v", t.Value, t.Frequency)
 }

--- a/meta/bagging_test.go
+++ b/meta/bagging_test.go
@@ -1,20 +1,21 @@
 package meta
 
 import (
+	"math/rand"
+	"testing"
+	"time"
+
 	"github.com/sjwhitworth/golearn/base"
 	"github.com/sjwhitworth/golearn/evaluation"
 	"github.com/sjwhitworth/golearn/filters"
 	"github.com/sjwhitworth/golearn/trees"
 	. "github.com/smartystreets/goconvey/convey"
-	"math/rand"
-	"testing"
-	"time"
 )
 
 func BenchmarkBaggingRandomForestFit(t *testing.B) {
 	inst, err := base.ParseCSVToInstances("../examples/datasets/iris_headers.csv", true)
 	if err != nil {
-		t.Fatal("Unable to parse CSV to instances: %s", err.Error())
+		t.Fatalf("Unable to parse CSV to instances: %s", err.Error())
 	}
 
 	rand.Seed(time.Now().UnixNano())
@@ -39,7 +40,7 @@ func BenchmarkBaggingRandomForestFit(t *testing.B) {
 func BenchmarkBaggingRandomForestPredict(t *testing.B) {
 	inst, err := base.ParseCSVToInstances("../examples/datasets/iris_headers.csv", true)
 	if err != nil {
-		t.Fatal("Unable to parse CSV to instances: %s", err.Error())
+		t.Fatalf("Unable to parse CSV to instances: %s", err.Error())
 	}
 
 	rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
Fix a bunch of Go vet complains, most of them are just incorrect or missing `fmt` arguments.
Here is the list of **Before/After**:

### Before
anzellai/golearn - [fix/go-vet-complaints] » `go vet ./...`

>base/categorical.go:13: struct field values has json tag but is not exported
>base/conversion.go:12: result of fmt.Errorf call not used
>base/filtered.go:160: arg as for printf verb %s of wrong type: base.AttributeSpec
>base/filtered.go:180: arg a for printf verb %s of wrong type: base.AttributeSpec
>base/fixed.go:72: wrong number of args for format in Sprintf call: 1 needed but 2 args
>base/serialize.go:135: struct field tag `json:type` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
>base/serialize.go:136: struct field tag `json:name` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
>base/serialize.go:137: struct field tag `json:attr` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
>exit status 1
>clustering/clustering.go:69: arg clusterIdMap for printf verb %s of wrong type: map[int]int
>clustering/clustering.go:100: arg ref[cNew] for printf verb %s of wrong type: []int
>exit status 1
>filters/binning.go:34: arg b.attrs for printf verb %d of wrong type: map[invalid type]bool
>filters/chimerge_freq.go:13: arg t.Frequency for printf verb %s of wrong type: map[string]int
>exit status 1
>meta/bagging_test.go:17: possible formatting directive in Fatal call
>meta/bagging_test.go:42: possible formatting directive in Fatal call
>exit status 1


### After
anzellai/golearn - [fix/go-vet-complaints●] » `go vet ./...`
anzellai/golearn - [fix/go-vet-complaints●] »
