### PR TITLE
fix(id3): fix panic on SplitAttribute being nil

### DIFF
--- a/trees/id3.go
+++ b/trees/id3.go
@@ -113,7 +113,7 @@ func InferID3Tree(from base.FixedDataGrid, with RuleGenerator) *DecisionTreeNode
 
 	// Generate the splitting rule
 	splitRule := with.GenerateSplitRule(from)
-	if splitRule == nil {
+	if splitRule == nil || splitRule.SplitAttr == nil {
 		// Can't determine, just return what we have
 		return ret
 	}


### PR DESCRIPTION
I ran into this while training a RandomForrest with 200 trees, and 15 (out of 19) features. I'm not sure if this is the right place to fix the error (or whether `SplitAttr` should just never be `nil`) , but it seems to be working.

A stack trace of the crash I was experiencing:

```
panic: Invalid Attribute index %!s(<nil>)

goroutine 57 [running]:
panic(0x9a2940, 0xc42027e100)
        /home/ryan/.gvm/gos/go1.7beta1/src/runtime/panic.go:500 +0x1a1
github.com/sjwhitworth/golearn/base.DecomposeOnAttributeValues(0xf57460, 0xc4203e83c0, 0x0, 0x0, 0x0)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/base/util_instances.go:329 +0x799
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4203e83c0, 0xf4dea0, 0xf89b50, 0xc42021e1a8)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:128 +0x863
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4203e9b40, 0xf4dea0, 0xf89b50, 0xc420199048)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4203e9800, 0xf4dea0, 0xf89b50, 0xc420198ce8)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4201decc0, 0xf4dea0, 0xf89b50, 0xc42021fdc8)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc420151b40, 0xf4dea0, 0xf89b50, 0xc42021fca8)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc420151000, 0xf4dea0, 0xf89b50, 0xc42021fb88)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4203d7f40, 0xf4dea0, 0xf89b50, 0xc42021f828)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4203d7540, 0xf4dea0, 0xf89b50, 0xc42021f5e8)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4204748c0, 0xf4dea0, 0xf89b50, 0xc4202ed3a8)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc420267cc0, 0xf4dea0, 0xf89b50, 0xc420097dc8)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4203d6dc0, 0xf4dea0, 0xf89b50, 0xc420199958)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4203d6f00, 0xf4dea0, 0xf89b50, 0xc420180648)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.InferID3Tree(0xf57460, 0xc4202ebf00, 0xf4dea0, 0xf89b50, 0x10)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:134 +0x6e0
github.com/sjwhitworth/golearn/trees.(*ID3DecisionTree).Fit(0xc4201ed560, 0xf57460, 0xc4202ebf00, 0xc4202669c0, 0xf57460)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/trees/id3.go:325 +0x13b
github.com/sjwhitworth/golearn/meta.(*BaggedModel).Fit.func1(0xc420266a80, 0xc4202c50a0, 0xf537e0, 0xc4201ed560, 0xf57460, 0xc4202669c0, 0x12)
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/meta/bagging.go:89 +0x71
created by github.com/sjwhitworth/golearn/meta.(*BaggedModel).Fit
        /home/ryan/Dev/go/src/github.com/sjwhitworth/golearn/meta/bagging.go:91 +0x14e
```