### PR TITLE
travis: stop testing tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
  - 1.5
  - 1.6
  - 1.7
- - tip
+ - 1.8
 env:
  # Temporary workaround for go 1.6
  - GODEBUG=cgocheck=0


### PR DESCRIPTION
tip seems to always fail at the moment due to a problem with
the unit testing framework. Disabling tip for now until the problem
is resolved.

https://github.com/smartystreets/goconvey/issues/476